### PR TITLE
feat: Sidebar styling

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,21 +1,23 @@
-import { Search as SearchIcon } from "@carbon/icons-react"
+import { Search as SearchIcon, SettingsAdjust } from "@carbon/icons-react"
+import { toggleSidebar } from "lib/store"
 
 const Search = () => {
   return (
-    <div className="flex items-stretch h-10">
+    <div className="flex items-stretch h-10 justify-center">
       <SearchIcon size={24} color={"white"} className="mt-2" />
       <input
         type="text"
         placeholder="Search the atlas"
         className="pl-2 bg-transparent text-white"
       />
+      <SettingsAdjust size={24} className="text-white mt-2 mr-4 cursor-pointer" onClick={toggleSidebar}/>
       <button className="bg-white text-black px-6 h-auto">Search</button>
     </div>
   )
 }
 
 const Header = () => (
-  <header className="absolute z-10 w-full flex justify-between pointer-events-none">
+  <header className="absolute z-10 w-full flex justify-between">
     <div className="p-10 w-1/3 text-white">
       <h1 className="text-4xl fill-black">The Atlas of Ownership</h1>
       <h2 className="text-xl">

--- a/components/sidebar/PatternClassAccordion.module.css
+++ b/components/sidebar/PatternClassAccordion.module.css
@@ -1,0 +1,7 @@
+.root {
+  @apply w-64 px-2 py-2 block cursor-pointer
+}
+
+.header {
+  @apply flex items-center justify-between
+}

--- a/components/sidebar/PatternClassAccordion.module.css
+++ b/components/sidebar/PatternClassAccordion.module.css
@@ -1,5 +1,5 @@
 .root {
-  @apply w-64 px-2 py-2 block cursor-pointer
+  @apply w-64 px-2 py-2 block cursor-pointer;
 }
 
 .header {

--- a/components/sidebar/PatternClassAccordion.tsx
+++ b/components/sidebar/PatternClassAccordion.tsx
@@ -46,7 +46,7 @@ const PatternClassAccordion = (props: Props) => {
               patterns,
               A.map((pattern) => (
                 <PatternClassAccordionPattern
-                  key={pattern.name}
+                  key={pattern._id}
                   pattern={pattern}
                 />
               ))

--- a/components/sidebar/PatternClassAccordion.tsx
+++ b/components/sidebar/PatternClassAccordion.tsx
@@ -1,9 +1,11 @@
+import css from "./PatternClassAccordion.module.css"
 import { pipe } from "fp-ts/lib/function"
 import { AnimatePresence, motion } from "framer-motion"
 import { useState } from "react"
 import { A } from "../../lib/fp"
 import { Pattern, PatternClass } from "../../lib/types"
 import PatternClassAccordionPattern from "./PatternClassAccordionPattern"
+import { ChevronDown, ChevronUp } from "@carbon/icons-react"
 
 type Props = {
   patternClass: PatternClass
@@ -21,14 +23,15 @@ const PatternClassAccordion = (props: Props) => {
   const [isOpen, setOpen] = useState(false)
 
   return (
-    <div style={{ backgroundColor: hex }} className="w-64">
-      <motion.header
-        className="h-8"
+    <details style={{ backgroundColor: hex }} className={css.root}>
+      <motion.summary
+        className={css.header}
         initial={false}
         onClick={() => setOpen(!isOpen)}
       >
         {name}
-      </motion.header>
+        {isOpen ? <ChevronUp size={24} /> : <ChevronDown size={24} />}
+      </motion.summary>
       <AnimatePresence initial={false}>
         {isOpen && (
           <motion.section
@@ -54,7 +57,7 @@ const PatternClassAccordion = (props: Props) => {
           </motion.section>
         )}
       </AnimatePresence>
-    </div>
+    </details>
   )
 }
 

--- a/components/sidebar/PatternClassAccordionPattern.module.css
+++ b/components/sidebar/PatternClassAccordionPattern.module.css
@@ -1,0 +1,19 @@
+.root {
+  @apply flex items-center py-2
+}
+
+.label {
+  @apply  w-full whitespace-nowrap text-sm text-left flex cursor-pointer justify-between
+}
+
+.labelText {
+  @apply flex justify-between items-center text-ellipsis overflow-hidden mr-2
+}
+
+.icon {
+  @apply mr-4 shrink-0
+}
+
+.checkbox {
+  @apply cursor-pointer shrink-0
+}

--- a/components/sidebar/PatternClassAccordionPattern.tsx
+++ b/components/sidebar/PatternClassAccordionPattern.tsx
@@ -17,14 +17,14 @@ const PatternClassAccordionPattern = ({ pattern }: Props) => {
         <p>{pattern.name}</p>
         </div>
         {patternNames.includes(pattern.name) ?
-          <RadioButtonChecked size={24} className={css.checkbox} /> :
-          <RadioButton size={24} className={css.checkbox} />
+          <RadioButtonChecked size={24} className={css.checkbox} role="checkbox" aria-checked="true"/> :
+          <RadioButton size={24} className={css.checkbox} role="checkbox" aria-checked="false"/>
         }
       </label>
       <input
         id={pattern._id}
         type="checkbox"
-        className="hidden peer"
+        className="hidden"
         onChange={(e) => {
           if (e.target.checked && !patternNames.includes(pattern.name)) {
             selection.patternNames.push(pattern.name)

--- a/components/sidebar/PatternClassAccordionPattern.tsx
+++ b/components/sidebar/PatternClassAccordionPattern.tsx
@@ -1,5 +1,7 @@
+import css from "./PatternClassAccordionPattern.module.css"
 import { Pattern } from "../../lib/types"
 import selection, { useSelection } from "./selection"
+import { Hotel, RadioButton, RadioButtonChecked } from "@carbon/icons-react"
 
 type Props = {
   pattern: Pattern
@@ -8,12 +10,21 @@ type Props = {
 const PatternClassAccordionPattern = ({ pattern }: Props) => {
   const { patternNames } = useSelection()
   return (
-    <div className="flex justify-between" key={pattern.name}>
-      <div className="overflow-hidden text-ellipsis w-full whitespace-nowrap">
-        {pattern.name}
-      </div>
+    <div key={pattern.name} className={css.root}>
+      <label className={css.label} htmlFor={pattern._id}>
+        <div className={css.labelText}>
+        <Hotel size={24} className={css.icon} />
+        <p>{pattern.name}</p>
+        </div>
+        {patternNames.includes(pattern.name) ?
+          <RadioButtonChecked size={24} className={css.checkbox} /> :
+          <RadioButton size={24} className={css.checkbox} />
+        }
+      </label>
       <input
+        id={pattern._id}
         type="checkbox"
+        className="hidden peer"
         onChange={(e) => {
           if (e.target.checked && !patternNames.includes(pattern.name)) {
             selection.patternNames.push(pattern.name)

--- a/components/sidebar/Sidebar.module.css
+++ b/components/sidebar/Sidebar.module.css
@@ -6,7 +6,6 @@
 .chevvy {
   @apply bg-white;
   @apply cursor-pointer;
-  /* @apply py-2; */
 }
 
 .chevvy > div {

--- a/components/sidebar/Sidebar.module.css
+++ b/components/sidebar/Sidebar.module.css
@@ -1,14 +1,15 @@
 .root {
-  @apply bg-red-500;
+  @apply bg-black;
   @apply absolute h-full z-10;
 }
 
 .chevvy {
   @apply bg-white;
   @apply cursor-pointer;
+  /* @apply py-2; */
 }
 
 .chevvy > div {
   @apply bg-inherit;
-  @apply flex justify-end pr-2;
+  @apply flex justify-end px-1 py-2;
 }

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import css from "@/styles/Sidebar.module.css"
+import css from "./Sidebar.module.css"
 import { pipe } from "fp-ts/lib/function"
 import { motion } from "framer-motion"
 import { useState } from "react"
@@ -6,20 +6,21 @@ import theme from "tailwindcss/defaultTheme"
 import { A } from "../../lib/fp"
 import { trpc } from "../../lib/trpc"
 import PatternClassAccordion from "./PatternClassAccordion"
+import { ChevronLeft, ChevronRight } from "@carbon/icons-react"
 
 const Chevvy = (props: any) => (
   <div className={css.chevvy} {...props}>
     <motion.div
       variants={{
         closed: {
-          x: `${theme.spacing[6]}`,
+          x: `${theme.spacing[8]}`,
         },
         open: {
           x: 0,
         },
       }}
     >
-      {props?.open ? `<` : `>`}
+      {props?.open ? <ChevronLeft size={24} /> : <ChevronRight size={24} />}
     </motion.div>
   </div>
 )

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -1,12 +1,12 @@
 import css from "./Sidebar.module.css"
 import { pipe } from "fp-ts/lib/function"
 import { motion } from "framer-motion"
-import { useState } from "react"
 import theme from "tailwindcss/defaultTheme"
 import { A } from "../../lib/fp"
 import { trpc } from "../../lib/trpc"
 import PatternClassAccordion from "./PatternClassAccordion"
 import { ChevronLeft, ChevronRight } from "@carbon/icons-react"
+import { toggleSidebar, useStore } from "lib/store"
 
 const Chevvy = (props: any) => (
   <div className={css.chevvy} {...props}>
@@ -26,8 +26,7 @@ const Chevvy = (props: any) => (
 )
 
 const Sidebar = () => {
-  const [open, setOpen] = useState(false)
-  const toggleOpen = () => void setOpen((p) => !p)
+  const isOpen = useStore().isSidebarOpen
 
   const { data: patternClasses = [] } = trpc.patternClasses.useQuery()
   const { data: patterns = [] } = trpc.patternsWithClass.useQuery()
@@ -42,7 +41,7 @@ const Sidebar = () => {
           x: 0,
         },
       }}
-      animate={open ? "open" : "closed"}
+      animate={isOpen ? "open" : "closed"}
       initial="closed"
       className={css.root}
       transition={{
@@ -52,7 +51,7 @@ const Sidebar = () => {
         stiffness: 120,
       }}
     >
-      <Chevvy onClick={toggleOpen} open={open} />
+      <Chevvy onClick={toggleSidebar} open={isOpen} />
       {pipe(
         patternClasses,
         A.map((patternClass) => (

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -7,7 +7,7 @@ export const entriesQuery = `*[_type == "entry"]{...,  mainImage {..., file {...
 export const entryBySlugQuery = `*[slug.current == $slug]`
 export const patternsQuery = `*[_type == "pattern"]`
 export const patternClassesQuery = `*[_type == "patternClass"] | order(order)`
-export const patternsWithClassQuery = `*[_type == "pattern"]{..., class -> }`
+export const patternsWithClassQuery = `*[_type == "pattern"]{..., class -> }[ count(*[_type == "entry" && references(^._id)]) > 0] | order(order)`
 
 export const useGetEntryFromSlug = () => {
   const { data: entries } = trpc.entries.useQuery()

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -8,6 +8,7 @@ type Store = {
   viewState: ViewState
   lastBirdseyeViewState: ViewState
   unclusteredSlugs: string[]
+  isSidebarOpen: boolean
 }
 
 const initialViewState: ViewState = {
@@ -23,7 +24,10 @@ const store = proxy<Store>({
   viewState: initialViewState,
   lastBirdseyeViewState: initialViewState,
   unclusteredSlugs: [],
+  isSidebarOpen: false,
 })
+
+export const toggleSidebar = () => store.isSidebarOpen = !store.isSidebarOpen;
 
 export const useStore = () => useSnapshot(store) as typeof store
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -18,6 +18,7 @@ export type Term = {
 }
 
 export type Pattern = {
+  _id: string
   name: string
   description: string
   class: PatternClass

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,15 +4,15 @@
 
 @layer base {
   :root {
-    --color-rent: 177 150 254;
-    --color-transfer: 135 212 255;
-    --color-administration: 226 226 226;
     --color-eligibility: 255 97 118;
     --color-security: 255 119 111;
+    --color-access: 255 163 55;
+    --color-use: 250 255 0;
     --color-develop: 210 249 100;
     --color-stewardship: 145 236 102;
-    --color-use: 250 255 0;
-    --color-access: 255 163 55;
+    --color-transfer: 135 212 255;
+    --color-rent: 177 150 254;
+    --color-administration: 226 226 226;
   }
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20502206/212721586-b582694b-d1fd-4783-ab65-54a67a539204.png)

Still to do...
 - Tidy up animations / transitions
 - Overflow Y for the sidebar. Spent a bit of time on this with no luck. `overflow-y-auto` on the sidebar solves our scrolling problem but this makes the chevron disappear. I'll come back to this 👌 

Ignored for now...
 - Empty "Use" category - this should be populated shortly by Niamh