### PR TITLE
fix: Render line breaks on Entry page

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -167,7 +167,7 @@ const Chart = (props: Props) => {
         <div className="flex-1 h-10 text-lg text-center text-gray-600">Rights</div>
       </div>
       {formattedTerms.map((term, i) => (
-        <div className="flex flex-col" key={`row-${term.name}-i`}>
+        <div className="flex flex-col" key={`row-${term.name}-${i}`}>
           <div className="flex" id="row-chart-data">
             {showLabels? <div className="flex-1 h-10 text-sm text-right mr-3 text-black" id="labels">{term.name}</div> : ``}
             <div 

--- a/components/layout/EntryLayout.tsx
+++ b/components/layout/EntryLayout.tsx
@@ -84,7 +84,7 @@ const EntryDetails = (entry?: Entry) => (
       }
     />
     <EntryItem heading="" className="col-span-4">
-      <p className="text-sm mb-2">{entry?.description}</p>
+      <p className="text-sm mb-2 whitespace-pre-wrap">{entry?.description}</p>
     </EntryItem>
     {entry?.references?.length && (
       <EntryItem heading="More information" className="col-span-3">

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -80,5 +80,6 @@ export enum TenureType {
   freehold = "Freehold",
   renting = "Renting",
   communityLandTrust = "Community Land Trust",
+  collectiveOwnership = "Collective Ownership",
   other = "Other",
 }


### PR DESCRIPTION
From Ollie on Slack - 

> just doing a quick bit of content stuff--are we able to get line breaks in the descriptions? eg in [Andelsbolig page](https://gorgeous-concha-ffb906.netlify.app/entry/andelsbolig), line breaks are shown in Sanity before and after "Legal Context" and "Historical Context" but not in the frontend, tried break tags too but it just shows the tags as text...

![image](https://user-images.githubusercontent.com/20502206/213463262-abb9420d-b8bc-451d-b00f-5e061a6d8592.png)
