### PR TITLE
fix: Custom marker style

### DIFF
--- a/components/map/Markers.tsx
+++ b/components/map/Markers.tsx
@@ -68,7 +68,9 @@ const Marker = (props: MarkerProps) => {
         longitude={lng}
         latitude={lat}
         onClick={onMarkerClick}
-      />
+      >
+      <div className="bg-white rounded-full h-7 w-7 flex justify-center items-center">1</div>
+      </MapboxMarker>
       {showPopup && (
         <Popup
           className="z-50"


### PR DESCRIPTION
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/20502206/213566899-8f36e834-4e4e-47ff-ab24-9e92f7d5caa7.png">


Marker (seen in Portugal) now matches style of clusters and Figma 👌 