### PR TITLE
fix: better charts

### DIFF
--- a/components/layout/EntryLayout.tsx
+++ b/components/layout/EntryLayout.tsx
@@ -119,7 +119,7 @@ export const EntryLayout = (props: EntryLayoutProps) => {
       {}
       <EntryHeader {...entry} />
       <EntryDetails {...entry} />
-      <Chart rollupToPatternClass={false} showLabels={true} terms={entry?.terms} patterns={patterns} patternClasses={patternClasses} entryId={entry?._id} />
+      <Chart rollupToPatternClass={false} showLabels={true} terms={entry?.terms} entryId={entry?._id} />
       { entry?.tenureType && <Carousel data={carouselItems} title={`Other examples of ${getFormattedTenureTypes(entry?.tenureType)}`} cardClassNames="bg-gray-200"/> }
       { entry?.location?.geopoint && <StaticMapImage {...entry}/>}
       {/* <Footer /> */}


### PR DESCRIPTION
this file was getting a little gnarly

now tidier and updated with:
- consistent flex grid styles used for bar chart sizing _and_ PatternsLayout page now
- better type interfaces
- no more unused tailwind classes

looking pretty good i think! 
![Screenshot from 2023-01-19 23-00-23](https://user-images.githubusercontent.com/5132349/213572290-c13c9ee6-8921-4fd3-96e2-fc1cd5cd2f5b.png)

still outstanding but hopefully much easier with new code structure (anyone please feel free to pick up!):
- [ ] option to pass in height variable for better-fit in map markers
- [ ] see if term-level labels can be aligned closer to bars like in figma, rather than 4 equal columns
- [ ] `showIcon` prop to toggle displaying the icon for this term at the end of its' bar
