### PR TITLE
fix: Entry Carousel & Explore Patterns navbar

### DIFF
--- a/components/PageNavbar.tsx
+++ b/components/PageNavbar.tsx
@@ -1,0 +1,15 @@
+import { Close } from "@carbon/icons-react"
+import Link from "next/link"
+
+export const PageNavbar = (props: { variant?: "light" }) => {
+  const { variant } = props
+
+  return (
+    <nav className={`flex justify-between ml-8 mr-8 mt-3 h-12 ${variant == "light" ? "text-black" : ""}`}>
+      <Link href="/" className="cursor-pointer">Atlas of Ownership</Link>
+      <Link href="/" className="text-lg">
+        <Close size={24} className="cursor-pointer" />
+      </Link>
+    </nav>
+  )
+}

--- a/components/carousel/Carousel.tsx
+++ b/components/carousel/Carousel.tsx
@@ -18,9 +18,9 @@ const CarouselItem = (props: { item: CarouselItem, cardClassNames: string | unde
         <div className="flex flex-col justify-between">
           <div className="flex justify-between w-full">
             <p>{props.item.name}</p>
-            <ArrowRight size={24}/>
+            <ArrowRight size={24} />
           </div>
-        <p className="text-xs">{props.item.location?.region}</p>
+          <p className="text-xs">{props.item.location?.region}</p>
         </div>
         <p className="text-xs">{getFormattedEntryDates(props.item?.dates)}</p>
       </a>
@@ -28,13 +28,13 @@ const CarouselItem = (props: { item: CarouselItem, cardClassNames: string | unde
   )
 }
 
-export const Carousel = (props: CarouselProps ) => (
+export const Carousel = (props: CarouselProps) => (
   <div className={css.root}>
     <p className={css.title}>{props.title}</p>
-    <div className={css.container}>  
+    <div className={css.container}>
       <div className={css.carousel}>
-        { props.data?.map((item, i) => (
-          <CarouselItem key={`${item}-${i}`} item={item} cardClassNames={props.cardClassNames}/>
+        {props.data?.map((item, i) => (
+          <CarouselItem key={`${item}-${i}`} item={item} cardClassNames={props.cardClassNames} />
         ))}
       </div>
     </div>

--- a/components/layout/EntryLayout.tsx
+++ b/components/layout/EntryLayout.tsx
@@ -10,8 +10,6 @@ import { Tag } from "./ui/Tag"
 
 interface EntryLayoutProps {
   entry?: Entry
-  patterns?: Pattern[]
-  patternClasses?: PatternClass[]
   carouselItems?: CarouselItem[]
 }
 

--- a/components/layout/NoopLayout.tsx
+++ b/components/layout/NoopLayout.tsx
@@ -1,6 +1,5 @@
-import { Close } from "@carbon/icons-react"
-import Link from "next/link"
 import { PropsWithChildren, ReactElement } from "react"
+import { PageNavbar } from "../PageNavbar"
 
 type Props = PropsWithChildren<{}>
 
@@ -9,12 +8,7 @@ const NoopLayoutComponent = (props: Props) => {
 
   return (
     <div className="bg-black z-20 text-white max-w-full fixed inset-0 overflow-y-auto overflow-x-auto">
-      <nav className="flex justify-between ml-8 mr-8 mt-3 h-12">
-        <Link href="/" className="cursor-pointer">Atlas of Ownership</Link>
-        <Link href="/" className="text-lg">
-          <Close size={24} className="cursor-pointer" />
-        </Link>
-      </nav>
+      <PageNavbar/>
       <div className="m-8">
         {children}
       </div>

--- a/components/layout/PatternsLayout.tsx
+++ b/components/layout/PatternsLayout.tsx
@@ -1,9 +1,9 @@
 import { trpc } from "@/lib/trpc";
 import { Pattern, PatternClass } from "@/lib/types"
-import { ArrowLeft, Hotel } from "@carbon/icons-react";
+import { Hotel } from "@carbon/icons-react";
 import clsx from "clsx";
 import { Dispatch, SetStateAction, useState } from "react";
-import Back from "../Back";
+import { PageNavbar } from "../PageNavbar";
 
 interface PatternsLayoutProps {
   patternClasses?: PatternClass[]
@@ -22,10 +22,7 @@ const patternClassLookup: Record<string, string> = {
 } as const;
 
 const Header = () => (
-  <header className="bg-gray-200 p-8">
-    <Back>
-      <ArrowLeft size={32} className="cursor-pointer" />
-    </Back>
+  <header className="bg-gray-200 px-8 pb-8">
     <h1 className="text-5xl mt-8 mb-8">Explore the patterns</h1>
     <h2 className="text-2xl mb-2">What is ownership?</h2>
     <p className="mb-8">Property is often described as a &quot;bundle&quot; of rights and obligations. We can unbundle these rights into 8 classes.</p>
@@ -52,7 +49,7 @@ const PatternList = (props: { patternClass: PatternClass | undefined }) => {
   const { patternClass } = props;
   const { data: patternInfo, error: patternInfoError } = trpc.patternInfo.useQuery({ patternClassName: patternClass?.name || null })
   return (
-    <section className="p-8">
+    <section className="p-8 bg-white">
       <p className="mb-4">{patternClass?.description}</p>
       <h3 className="text-lg mb-4">Rights</h3>
       {patternInfo?.rights.map((pattern, i) => (
@@ -94,7 +91,8 @@ export const PatternsLayout = (props: PatternsLayoutProps) => {
   const [selectedPatternClass, setSelectedPatternClass] = useState<PatternClass | undefined>(patternClasses?.[0]);
 
   return (
-    <div className="bg-white z-20 fixed inset-0 overflow-y-auto">
+    <div className="bg-gray-200 text-black z-20 fixed inset-0 overflow-y-auto">
+      <PageNavbar variant="light" />
       <Header />
       <PatternNav patternClasses={patternClasses} onClick={setSelectedPatternClass} selectedPatternClass={selectedPatternClass} />
       <PatternList patternClass={selectedPatternClass} />

--- a/pages/entry/[slug].tsx
+++ b/pages/entry/[slug].tsx
@@ -1,3 +1,4 @@
+import { trpc } from "@/lib/trpc"
 import { useRouter } from "next/router"
 import { useEffect, useMemo } from "react"
 import { EntryLayout } from "../../components/layout/EntryLayout"
@@ -22,7 +23,10 @@ const EntryPage = () => {
     store.map?.flyTo({ center: { lat, lng }, zoom: 18 })
   }, [entry])
 
-  return entry ? <EntryLayout entry={entry} /> : null
+
+  const { data: carouselItems, error: carouselItemsError } = trpc.tenureType.useQuery({ tenureTypes: entry?.tenureType, id: entry?._id })
+
+  return entry ? <EntryLayout entry={entry} carouselItems={carouselItems} /> : null
 }
 
 export default EntryPage


### PR DESCRIPTION
A few things missed whilst merging / rebasing - 

 - `carouselItems` are now passed into `EntryLayout` to display items at bottom of page
 - "Explore the patterns" page now has the standard header
   - Another (maybe better, but more complex) would have been a refactor of `NoopLayout` to account for different colour pages. Happy to have a crack at this time allowing.

![image](https://user-images.githubusercontent.com/20502206/213723933-ebcf78fd-2f1b-4bf1-b3e3-0b26cd282ec3.png)
