### PR TITLE
fix: correct chart math using term "strength"

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -87,7 +87,7 @@ const DataRow = (props: DataRowProps) => {
   return (
     <div className="flex">
       {showLabels ? (
-        <div className="w-1/5 h-10 text-black flex items-center justify-end mr-3">
+        <div className="w-1/5 h-10 text-black text-right flex items-center justify-end mr-3">
           {patternClass.name}
         </div> 
       ) : (``)}
@@ -224,6 +224,8 @@ const Chart = (props: Props) => {
     }))
     .sortBy('patternClassOrder', 'name')
     .value();
+  
+  console.log(formattedTerms);
 
   // Group terms by pattern
   let totalsByPattern = _(terms)
@@ -272,6 +274,8 @@ const Chart = (props: Props) => {
     }))
     .sortBy('meta.order')
     .value();
+
+  console.log(totalsByPatternClass);
 
   return rollupToPatternClass ? (
     <BarChartByPatternClass data={totalsByPatternClass} showLabels={showLabels} />

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -211,7 +211,7 @@ const Chart = (props: Props) => {
     .map((term: any) => ({
       pattern: _.find(patterns, ['_id', term.pattern?._ref]),
       patternName: _.find(patterns, ['_id', term.pattern?._ref])?.name,
-      type: term.rightsIntensity > 0 ? "Right" : "Obligation", // because pattern.type is not consistently populated
+      type: _.capitalize(_.find(patterns, ['id', term.pattern?._ref])?.type) || term.rightsIntensity > 0 ? "Right" : "Obligation", // because pattern.type is not consistently populated
       strength: term.strength, // 1-5
     }))
     .map((term: any) => ({
@@ -224,28 +224,16 @@ const Chart = (props: Props) => {
     }))
     .sortBy('patternClassOrder', 'name')
     .value();
-  
-  console.log(formattedTerms);
 
-  // Group terms by pattern
-  let totalsByPattern = _(terms)
-    .groupBy('pattern._ref')
-    .map((term: any) => ({
-      pattern: _.find(patterns, ['_id', term[0].pattern._ref]),
-      patternName: _.find(patterns, ['_id', term[0].pattern._ref])?.name,
-      sumRights: _.sumBy(term, 'rightsIntensity'),
-      sumObligations: _.sumBy(term, 'obligationIntensity')
-    }))
-    .value();
-
-  // Rollup to pattern class, taking the average rights & obligations from each pattern rounded to nearest integer
-  let totalsByPatternClass = _(totalsByPattern)
-    .groupBy('pattern.class._ref')
-    .map((pattern: any) => ({
-      meta: _.find(patternClasses, ['_id', pattern[0].pattern?.class._ref]),
-      name: _.find(patternClasses, ['_id', pattern[0].pattern?.class._ref])?.name,
-      avgRights: _.round(_.meanBy(pattern, 'sumRights')),
-      avgObligations: _.round(_.meanBy(pattern, 'sumObligations')),
+  // Rollup the individual terms by their pattern class
+  let totalsByPatternClass = _(formattedTerms)
+    .groupBy('patternClassName')
+    .map((terms: any) => ({
+      terms: terms,
+      meta: _.find(patternClasses, ['_id', terms[0].meta?.class._ref]),
+      name: terms[0].patternClassName,
+      avgRights: _(terms).filter({ type: "Right" }).meanBy("strength"),
+      avgObligations: _(terms).filter({ type: "Obligation" }).meanBy("strength"),
     }))
     .sortBy('meta.order')
     .value();
@@ -255,6 +243,7 @@ const Chart = (props: Props) => {
     patternClasses?.forEach(globalPatternClass => {
       if (!_.find(totalsByPatternClass, ['name', globalPatternClass.name])) {
         totalsByPatternClass.push({
+          terms: [],
           meta: globalPatternClass,
           name: globalPatternClass.name,
           avgRights: 0,
@@ -264,18 +253,17 @@ const Chart = (props: Props) => {
     });
   }
 
-  // Replace any NaNs with 0 and do a final sort
+  // Replace any NaNs with 0, round to nearest integer, and do a final sort
   totalsByPatternClass = _(totalsByPatternClass)
-    .map((pattern: any) => ({
-      meta: pattern.meta,
-      name: pattern.name,
-      avgRights: pattern.avgRights > 0 ? pattern.avgRights : 0,
-      avgObligations: pattern.avgObligations > 0 ? pattern.avgObligations : 0,
+    .map((patternClass: any) => ({
+      terms: patternClass.terms,
+      meta: patternClass.meta,
+      name: patternClass.name,
+      avgRights: patternClass.avgRights > 0 ? _.round(patternClass.avgRights) : 0,
+      avgObligations: patternClass.avgObligations > 0 ? _.round(patternClass.avgObligations) : 0,
     }))
     .sortBy('meta.order')
     .value();
-
-  console.log(totalsByPatternClass);
 
   return rollupToPatternClass ? (
     <BarChartByPatternClass data={totalsByPatternClass} showLabels={showLabels} />

--- a/components/layout/EntryLayout.tsx
+++ b/components/layout/EntryLayout.tsx
@@ -19,6 +19,10 @@ interface EntryItemProps {
   children?: React.ReactNode
 }
 
+// "true" enables toggling between two chart styles
+//    helpful for debugging math between pattern classes & individual terms!
+const DEBUG_CHARTS = false;
+
 const EntryHeader = (entry?: Entry) => (
   <div
     // TODO: The sanity image pipeline could get us an optimized image here
@@ -108,7 +112,7 @@ const EntryDetails = (entry?: Entry) => (
 
 export const EntryLayout = (props: EntryLayoutProps) => {
   const { entry, carouselItems } = props
-  const [ showRollup, setShowRollup ] = useState(true);
+  const [ showRollup, setShowRollup ] = useState(false);
 
   return (
     <div className="text-white">
@@ -120,35 +124,37 @@ export const EntryLayout = (props: EntryLayoutProps) => {
         terms={entry?.terms}
         entryId={entry?._id}
       />
-      <form className="flex m-3 p-3 bg-gray-200">
-        <div className="text-black text-sm mr-2">
-          Chart by:
-        </div>
-        <div className="radio text-black text-sm mr-3">
-          <label>
-            <input
-              type="radio"
-              value="patternClass"
-              checked={showRollup === true}
-              onChange={() => setShowRollup(!showRollup)}
-              className="mr-1 ml-1"
-            />
-            Pattern class
-          </label>
-        </div>
-        <div className="radio text-black text-sm mr-3">
-          <label>
-            <input
-              type="radio"
-              value="term"
-              checked={showRollup === false}
-              onChange={() => setShowRollup(!showRollup)}
-              className="mr-1 ml-1"
-            />
-            Terms
-          </label>
-        </div>
-      </form>
+      {DEBUG_CHARTS && (
+        <form className="flex m-3 p-3 bg-gray-200">
+          <div className="text-black text-sm mr-2">
+            Chart by:
+          </div>
+          <div className="radio text-black text-sm mr-3">
+            <label>
+              <input
+                type="radio"
+                value="patternClass"
+                checked={showRollup === true}
+                onChange={() => setShowRollup(!showRollup)}
+                className="mr-1 ml-1"
+              />
+              Pattern class
+            </label>
+          </div>
+          <div className="radio text-black text-sm mr-3">
+            <label>
+              <input
+                type="radio"
+                value="term"
+                checked={showRollup === false}
+                onChange={() => setShowRollup(!showRollup)}
+                className="mr-1 ml-1"
+              />
+              Terms
+            </label>
+          </div>
+        </form>
+      )}
       {entry?.tenureType && (
         <Carousel
           data={carouselItems}

--- a/components/layout/EntryLayout.tsx
+++ b/components/layout/EntryLayout.tsx
@@ -1,8 +1,8 @@
 import { getFormattedEntryDates, getFormattedTenureTypes } from "@/lib/entry"
 import { ArrowRight, ArrowUpRight, Close } from "@carbon/icons-react"
 import Link from "next/link"
-import { Fragment } from "react"
-import { CarouselItem, Entry, Pattern, PatternClass } from "../../lib/types"
+import { useState } from "react"
+import { CarouselItem, Entry } from "../../lib/types"
 import Back from "../Back"
 import { Carousel } from "../carousel/Carousel"
 import Chart from "../Chart"
@@ -108,16 +108,47 @@ const EntryDetails = (entry?: Entry) => (
 
 export const EntryLayout = (props: EntryLayoutProps) => {
   const { entry, carouselItems } = props
+  const [ showRollup, setShowRollup ] = useState(true);
+
   return (
     <div className="text-white">
       <EntryHeader {...entry} />
       <EntryDetails {...entry} />
       <Chart
-        rollupToPatternClass={false}
+        rollupToPatternClass={showRollup}
         showLabels={true}
         terms={entry?.terms}
         entryId={entry?._id}
       />
+      <form className="flex m-3 p-3 bg-gray-200">
+        <div className="text-black text-sm mr-2">
+          Chart by:
+        </div>
+        <div className="radio text-black text-sm mr-3">
+          <label>
+            <input
+              type="radio"
+              value="patternClass"
+              checked={showRollup === true}
+              onChange={() => setShowRollup(!showRollup)}
+              className="mr-1 ml-1"
+            />
+            Pattern class
+          </label>
+        </div>
+        <div className="radio text-black text-sm mr-3">
+          <label>
+            <input
+              type="radio"
+              value="term"
+              checked={showRollup === false}
+              onChange={() => setShowRollup(!showRollup)}
+              className="mr-1 ml-1"
+            />
+            Terms
+          </label>
+        </div>
+      </form>
       {entry?.tenureType && (
         <Carousel
           data={carouselItems}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,3 @@
-import { Carousel } from './../components/carousel/Carousel';
 export type Geopoint = {
   lat: number
   lng: number
@@ -16,6 +15,7 @@ export type Term = {
   pattern: Pattern
   rightsIntensity?: IntensityRange
   obligationIntensity?: IntensityRange
+  strength: IntensityRange
 }
 
 export type Pattern = {
@@ -24,6 +24,7 @@ export type Pattern = {
   description: string
   class: PatternClass
   entryCount?: number
+  type: "right" | "obligation"
 }
 
 export type PatternClass = {


### PR DESCRIPTION
was noticing that some of "rolled up to pattern class" charts were not matching the charts "by terms"

see example:
- https://deploy-preview-58--gorgeous-concha-ffb906.netlify.app/entry/freehold-in-alentejo

chart math now corrected & simplified to reference `term.strength` which is consistently populated I think rather than the old `rightsIntensity` & `obligationsIntensity`

also added a little local feature-flag-esque toggle `DEBUG_CHART` which we can manually set from entry page to display a simple radio button to easily toggle between chart variations - otherwise it's a little clumsy to compare the map markers to the entry page.
![Screenshot from 2023-01-22 13-13-58](https://user-images.githubusercontent.com/5132349/213920135-b88ca590-0217-41de-8250-d83b904c04a8.png)