### PR TITLE
feat: when expanding a chart row, show term definition and its' unique description for this entry

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -110,14 +110,18 @@ const ExpandableRow = (props: ExpandableRowProps) => {
 
   return (
     <div
-      className={`flex flex-col h-fit w-full text-black ${term.patternClassName ? descriptionBackgroundColorClasses[term.patternClassName] : 'bg-gray-200'}`}
+      className={`flex flex-col h-fit w-full text-black ${term.patternClassName ? descriptionBackgroundColorClasses[term.patternClassName] : 'bg-gray-200'} cursor-pointer`}
       id="row-expandable-description"
       onClick={onClick}
     >
       <div className="p-4">
         <p className="text-sm text-right">{term.patternClassName} {term.type.toLowerCase()}</p>
-        <h2 className="text-base mb-1">{term.name}</h2>
-        <p className="text-sm">{term.meta?.description}</p>
+        <h2 className="text-lg">{term.name}</h2>
+        <p className="text-sm mb-6">{term.meta?.description}</p>
+        <div>
+          <h3>How it applies here</h3>
+          <p className="text-sm">{term?.description}</p>
+        </div>
       </div>
       {showCarousel && <Carousel data={carouselItems} title="Other places that use this pattern" cardClassNames={clsx(`${backgroundColorClasses[term.patternClassName]} bg-opacity-20`)} />}
     </div>
@@ -147,6 +151,14 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
   const [open, setOpen] = useState(false)
   const [openIndex, setOpenIndex] = useState(0)
 
+  const handleClick = (i: number) => {
+    if (open) {
+      setOpenIndex(i);
+    } else {
+      setOpen(!open);
+    }
+  }
+
   return (
     <div className="m-4">
       <div className="flex">
@@ -165,10 +177,7 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
               <div 
                 className={`${term.type === "Obligation" && term.strength > 0 && backgroundColorClasses[term.patternClassName!]} ${term.type === "Obligation" && term.strength > 0 && hoverColorClasses[term.patternClassName!]} h-10 cursor-pointer`} 
                 style={{ gridColumn: `span ${term.strength}` }}
-                onClick={() => {
-                  setOpen(!open);
-                  setOpenIndex(i);
-                }}
+                onClick={() => handleClick(i)}
               >
               </div>
             </div>
@@ -176,10 +185,7 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
               <div 
                 className={`${term.type === "Right" && term.strength > 0 && backgroundColorClasses[term.patternClassName!]} ${term.type === "Right" && term.strength > 0 && hoverColorClasses[term.patternClassName!]} h-10 cursor-pointer`} 
                 style={{ gridColumn: `span ${term.strength}` }}
-                onClick={() => {
-                  setOpen(!open);
-                  setOpenIndex(i);
-                }}
+                onClick={() => handleClick(i)}
               >
               </div>
             </div>
@@ -213,6 +219,7 @@ const Chart = (props: Props) => {
       patternName: _.find(patterns, ['_id', term.pattern?._ref])?.name,
       type: term.rightsIntensity > 0 ? "Right" : "Obligation", // because pattern.type is not consistently populated
       strength: term.strength, // 1-5
+      description: term.description,
     }))
     .map((term: any) => ({
       meta: term.pattern,
@@ -221,6 +228,7 @@ const Chart = (props: Props) => {
       patternClassOrder: _.find(patternClasses, ['_id', term.pattern?.class?._ref])?.order,
       type: term.type,
       strength: term.strength,
+      description: term.description,
     }))
     .sortBy('patternClassOrder', 'name')
     .value();


### PR DESCRIPTION
a term has: 
- description = how it applies to the given entry
- pattern.description = how the pattern is defined

realized we were leaving out the first description entirely! 

not really in figma, so made up a design myself for now - feedback welcome:
![Screenshot from 2023-01-22 18-19-16](https://user-images.githubusercontent.com/5132349/213930299-63f45507-df6d-4552-ac37-3cd1d8a88256.png)

