### PR TITLE
feat: Align labels with bars

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -138,11 +138,11 @@ const BarChartByPatternClass = (props: BarChartByPatternClassProps) => {
   const { data: totalsByPatternClass, showLabels } = props
 
   return (
-    <div className="m-4">
+    <div className="mt-4">
       <div className="flex">
         {showLabels ? <div className="w-1/5 h-10"></div> : ``}
-        <div className="flex-1 h-10 text-lg text-center text-black">Obligations</div>
-        <div className="flex-1 h-10 text-lg text-center text-black">Rights</div>
+        <div className="flex-1 h-10 text-lg text-center text-gray-500">Obligations</div>
+        <div className="flex-1 h-10 text-lg text-center text-gray-500 ">Rights</div>
       </div>
       {totalsByPatternClass.map(patternClass => (
         <DataRow patternClassTotal={patternClass} showLabels={showLabels} key={`data-row-${patternClass.name}`} />

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -174,12 +174,7 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
       {formattedTerms.map((term: any, i: number) => (
         <div className="flex flex-col" key={`row-${term.name}-${i}`}>
           <div className="flex">
-            {showLabels ? (
-              <div className="flex-1 h-10 text-black text-sm text-right flex items-center justify-end mr-3">
-                {term.type === "Obligation" && term.name}
-              </div>
-            ) : (``)}
-            <div className="flex-1 grid" style={{ gridTemplateColumns: `repeat(5, minmax(0, 1fr))`, direction: "rtl"}}>
+            <div className="flex-1 grid" style={{ gridTemplateColumns: `repeat(8, minmax(0, 1fr))`, direction: "rtl"}}>
               <div 
                 className={`${term.type === "Obligation" && term.strength > 0 && backgroundColorClasses[term.patternClassName!]} ${term.type === "Obligation" && term.strength > 0 && hoverColorClasses[term.patternClassName!]} h-10 cursor-pointer flex justify-end items-center`} 
                 style={{ gridColumn: `span ${term.strength}` }}
@@ -187,8 +182,13 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
               >
                 {term.type === "Obligation" && term.strength > 0 && <Tree size={16} color="black" className="ml-2" />}
               </div>
+              {showLabels &&
+                <div className="flex-1 h-10 text-black text-sm flex items-center mr-3 text-right" style={{ gridColumn: `span ${8 - term.strength}` }}>
+                  {term.type === "Obligation" && term.name}
+                </div>
+              }
             </div>
-            <div className="flex-1 grid" style={{ gridTemplateColumns: `repeat(5, minmax(0, 1fr))`, direction: "ltr" }}>
+            <div className="flex-1 grid" style={{ gridTemplateColumns: `repeat(8, minmax(0, 1fr))`, direction: "ltr" }}>
               <div 
                 className={`${term.type === "Right" && term.strength > 0 && backgroundColorClasses[term.patternClassName!]} ${term.type === "Right" && term.strength > 0 && hoverColorClasses[term.patternClassName!]} h-10 cursor-pointer flex justify-end items-center`} 
                 style={{ gridColumn: `span ${term.strength}` }}
@@ -196,12 +196,12 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
               >
                 {term.type === "Right" && term.strength > 0 && <Tree size={16} color="black" className="mr-2" />}
               </div>
-            </div>
-            {showLabels ? (
-              <div className="flex-1 h-10 text-black text-sm flex items-center justify-start ml-3">
+            {showLabels &&
+                <div className="flex-1 h-10 text-black text-sm flex items-center justify-start ml-3" style={{ gridColumn: `span ${8 - term.strength}` }}>
                 {term.type === "Right" && term.name}
               </div> 
-            ) : (``)}
+            }
+            </div>
           </div>
           {
             open && openIndex === i &&

--- a/components/map/Markers.tsx
+++ b/components/map/Markers.tsx
@@ -73,7 +73,7 @@ const Marker = (props: MarkerProps) => {
       </MapboxMarker>
       {showPopup && (
         <Popup
-          className="z-50"
+          className="z-50 font-sans"
           longitude={lng}
           latitude={lat}
           maxWidth="none"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -16,15 +16,6 @@
   }
 }
 
-:root {
-  font-family: "Inter", sans-serif;
-}
-@supports (font-variation-settings: normal) {
-  :root {
-    font-family: "Inter var", sans-serif;
-  }
-}
-
 html,
 body {
   padding: 0;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,9 @@
 module.exports = {
   content: ["./**/*.tsx"],
   theme: {
+    fontFamily: {
+      sans: ["Inter", "sans-serif"],
+    },
     extend: {
       colors: {
         rent: 'rgb(var(--color-rent) / <alpha-value>)',


### PR DESCRIPTION
<img width="705" alt="image" src="https://user-images.githubusercontent.com/20502206/213937309-bac3da6a-970a-4a69-b8ea-bb9efb0d093b.png">

**What's going on here?**
 - Each row of the chart is now 8 fractions wide
 - Up to 5 columns are used for the values, the remainder for the labels
 - To make things align, we always make sure that the entire 8 columns are used 
 

TODO: 
 - Implement this on "rolled up" chart