### PR TITLE
fix: Don't block globe interactivity with header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,7 @@ import Link from "next/link"
 
 const Search = () => {
   return (
-    <div className="flex items-stretch h-10 justify-center">
+    <div className="flex items-stretch h-10 justify-center pointer-events-auto">
       <SearchIcon size={24} color={"white"} className="mt-2" />
       <input
         type="text"
@@ -18,14 +18,14 @@ const Search = () => {
 }
 
 const Header = () => (
-  <header className="absolute z-10 w-full flex justify-between">
+  <header className="absolute z-10 w-full flex justify-between pointer-events-none">
     <div className="p-10 w-1/4 text-white">
       <h1 className="text-4xl fill-black">The Atlas of Ownership</h1>
       <h2 className="text-lg pt-3">
         A map of property rights and obligations across time and space
       </h2>
       <Link href="/about">
-        <a className="text-lg text-gray-500" >Why?</a>
+        <a className="text-lg text-gray-500 pointer-events-auto" >Why?</a>
       </Link>
     </div>
     <Search />


### PR DESCRIPTION
To test - 
 - I can now interact with the globe behind the header
 - I can still click "Why?", and search / filter buttons

