### PR TITLE
fix: Hide chart if entry has no terms

### DIFF
--- a/components/layout/EntryLayout.tsx
+++ b/components/layout/EntryLayout.tsx
@@ -118,12 +118,12 @@ export const EntryLayout = (props: EntryLayoutProps) => {
     <div className="text-white">
       <EntryHeader {...entry} />
       <EntryDetails {...entry} />
-      <Chart
+      {entry?.terms?.length && <Chart
         rollupToPatternClass={showRollup}
         showLabels={true}
         terms={entry?.terms}
         entryId={entry?._id}
-      />
+      />}
       {DEBUG_CHARTS && (
         <form className="flex m-3 p-3 bg-gray-200">
           <div className="text-black text-sm mr-2">

--- a/components/map/Markers.tsx
+++ b/components/map/Markers.tsx
@@ -41,11 +41,11 @@ const Marker = (props: MarkerProps) => {
   const PopupContent = () => (
     <div className="w-[500px]">
       <h2 className="text-2xl">{entry?.name}</h2>
-      <Chart
+      {entry?.terms?.length && <Chart
         rollupToPatternClass={true}
         showLabels={true}
         terms={entry?.terms}
-      />
+      />}
       <Link
         href={`/entry/${encodeURIComponent(slug)}`}
         className="flex justify-end items-center text-lg"


### PR DESCRIPTION
Fixes https://www.notion.so/opensystemslab/The-Atlas-of-Ownership-176a5620cdfd4465aacb20562bfe64f7?p=8db264992a8d44ba8a02b49f41259ec7&pm=s

The above bug refers to "Social Renting - Secure Council Tenancy Norwich" which I can't locate on Sanity or on the map - I've asked Niamh about this to see if there's an underlying issue.

It's displayed here on the live preview - https://gorgeous-concha-ffb906.netlify.app/entry/social-renting-secure-council-tenancy