### PR TITLE
fix: Remove filter button from header

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,5 +1,4 @@
-import { Search as SearchIcon, SettingsAdjust } from "@carbon/icons-react"
-import { toggleSidebar } from "lib/store"
+import { Search as SearchIcon } from "@carbon/icons-react"
 import Link from "next/link"
 
 const Search = () => {
@@ -11,7 +10,6 @@ const Search = () => {
         placeholder="Search the atlas"
         className="pl-2 bg-transparent text-white"
       />
-      <SettingsAdjust size={24} className="text-white mt-2 mr-4 cursor-pointer" onClick={toggleSidebar}/>
       <button className="bg-white text-black px-6 h-auto">Search</button>
     </div>
   )

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -6,7 +6,8 @@ import { A } from "../../lib/fp"
 import { trpc } from "../../lib/trpc"
 import PatternClassAccordion from "./PatternClassAccordion"
 import { ChevronLeft, ChevronRight } from "@carbon/icons-react"
-import { toggleSidebar, useStore } from "lib/store"
+import { useStore } from "lib/store"
+import { useState } from "react"
 
 const Chevvy = (props: any) => (
   <div className={css.chevvy} {...props}>
@@ -26,7 +27,7 @@ const Chevvy = (props: any) => (
 )
 
 const Sidebar = () => {
-  const isOpen = useStore().isSidebarOpen
+  const [isOpen, setIsOpen] = useState(false)
 
   const { data: patternClasses = [] } = trpc.patternClasses.useQuery()
   const { data: patterns = [] } = trpc.patternsWithClass.useQuery()
@@ -51,7 +52,7 @@ const Sidebar = () => {
         stiffness: 120,
       }}
     >
-      <Chevvy onClick={toggleSidebar} open={isOpen} />
+      <Chevvy onClick={() => setIsOpen(!isOpen)} open={isOpen} />
       {pipe(
         patternClasses,
         A.map((patternClass) => (

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -8,7 +8,6 @@ type Store = {
   viewState: ViewState
   lastBirdseyeViewState: ViewState
   unclusteredSlugs: string[]
-  isSidebarOpen: boolean
 }
 
 const initialViewState: ViewState = {
@@ -24,10 +23,8 @@ const store = proxy<Store>({
   viewState: initialViewState,
   lastBirdseyeViewState: initialViewState,
   unclusteredSlugs: [],
-  isSidebarOpen: false,
 })
 
-export const toggleSidebar = () => store.isSidebarOpen = !store.isSidebarOpen;
 
 export const useStore = () => useSnapshot(store) as typeof store
 


### PR DESCRIPTION
Originally when I had implemented this, I thought the button was meant to toggle the `Sidebar` component. On the previous Atlas call Alastair said that this was meant to be a search functionality.

I've removed this button, and it's associated store actions.

Also: There is a white "flash" of the sidebar when it opens, both on this branch and on `main`. I think this is a transition thing and not a state / re-rendering issue.