### PR TITLE
feat: Get page content from Sanity

### DIFF
--- a/components/ContentPage.tsx
+++ b/components/ContentPage.tsx
@@ -1,0 +1,30 @@
+import { Page } from "@/lib/types"
+import { PortableText } from "@portabletext/react"
+import React from "react"
+
+export const pageComponents = {
+  block: {
+    normal: ({ children }: { children?: React.ReactNode }) => <p className="mb-4">{children}</p>,
+    blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className="text-gray-400 mb-4">{children}</blockquote>,
+  }
+}
+
+interface ContentPageProps {
+  page: Page
+}
+
+export const ContentPage = ({ page }: ContentPageProps) => {
+  return (
+    <div className="w-1/3">
+      <h1 className="text-5xl font-semibold mb-12">
+        {page?.title}
+      </h1>
+      <div className="flex flex-col">
+        <PortableText
+          value={page?.content}
+          components={pageComponents}
+        />
+      </div>
+    </div>
+  )
+}

--- a/lib/page.tsx
+++ b/lib/page.tsx
@@ -1,0 +1,8 @@
+import React from "react"
+
+export const pageComponents = {
+  block: {
+    normal: ({ children }: { children?: React.ReactNode }) => <p className="mb-4">{ children }</p>,
+    blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className="text-gray-400 mb-4">{ children }</blockquote>,
+  }
+}

--- a/lib/page.tsx
+++ b/lib/page.tsx
@@ -1,8 +1,0 @@
-import React from "react"
-
-export const pageComponents = {
-  block: {
-    normal: ({ children }: { children?: React.ReactNode }) => <p className="mb-4">{ children }</p>,
-    blockquote: ({ children }: { children?: React.ReactNode }) => <blockquote className="text-gray-400 mb-4">{ children }</blockquote>,
-  }
-}

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -4,9 +4,9 @@ import { O, RA } from "./fp"
 import { trpc } from "./trpc"
 import { Entry } from "./types"
 
-export const entriesQuery = `*[_type == "entry"]{...,  entryRating-> { grade }, mainImage {..., file {..., asset-> } }, 'patterns': terms[].pattern->{ name } }`
+export const entriesQuery = groq`*[_type == "entry"]{...,  entryRating-> { grade }, mainImage {..., file {..., asset-> } }, 'patterns': terms[].pattern->{ name } }`
 export const patternsQuery = groq`*[_type == "pattern"] {..., "iconUrl": icon.asset -> url} `
-export const patternClassesQuery = `*[_type == "patternClass"] | order(order)`
+export const patternClassesQuery = groq`*[_type == "patternClass"] | order(order)`
 export const patternsWithClassQuery = groq`
   *[_type == "pattern"]
   {..., class -> , "iconUrl": icon.asset -> url}
@@ -23,7 +23,7 @@ export const useGetEntryFromSlug = () => {
     )
 }
 
-export const patternInfoQuery = (patternClassName: string | null) => `
+export const patternInfoQuery = (patternClassName: string | null) => groq`
   {
     "rights": 
       *[_type == "pattern"] { 
@@ -49,7 +49,7 @@ export const patternInfoQuery = (patternClassName: string | null) => `
 export const tenureTypeQuery = (
   tenureTypes: string[] | undefined,
   id: string | undefined
-) => `
+) => groq`
   *[_type == "entry" && count((tenureType)
   [@ in ${JSON.stringify(tenureTypes)}]) > 0 && _id != "${id}"]
   { dates, slug, location, name, _id }
@@ -58,8 +58,10 @@ export const tenureTypeQuery = (
 export const entriesByPatternIdQuery = (
   patternId: string | undefined,
   entryId: string | undefined
-) => `
+) => groq`
     *[_type == "entry" && references("${patternId}") && _id != "${entryId}"]
     { dates, slug, location, name, _id }
 `
 export const contributorsQuery = groq`array::unique(*[_type == "entry" && defined(contributors)].contributors[].name)`
+
+export const pageQuery = (pageSlug: string | undefined) => groq`*[_type == "page" && slug == "${pageSlug}"][0]`

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,5 @@
+import { PortableTextBlockComponent } from "@portabletext/react"
+
 export type Geopoint = {
   lat: number
   lng: number
@@ -97,4 +99,10 @@ export type CarouselItem = Pick<Entry, "dates" | "location" | "name" | "slug">
 export type EntryType = {
   title: string
   value: string
+}
+
+export type Page = {
+  slug?: string
+  title?: string
+  content?: any[]
 }

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,25 +1,14 @@
-import { pageComponents } from "@/lib/page"
+import { ContentPage } from "@/components/ContentPage"
 import { trpc } from "@/lib/trpc"
-import { PortableText } from "@portabletext/react"
 import Image from "next/image"
 import NoopLayout from "../components/layout/NoopLayout"
 
 const AboutPage = () => {
-  const { data: page } = trpc.page.useQuery({ pageSlug: "about" })
+  const { data: aboutPage } = trpc.page.useQuery({ pageSlug: "about" })
 
   return (
     <div className="flex">
-      <div className="w-1/3">
-        <h1 className="text-5xl font-semibold mb-12">
-          { page?.title }
-        </h1>
-        <div className="flex flex-col w-3/4">
-          <PortableText
-            value={page?.content}
-            components={pageComponents}
-          />
-        </div>
-      </div>
+      <ContentPage page={aboutPage} />
       <div className="w-2/3 relative flex items-center justify-center">
         <Image
           src="/images/real-estate-value-diagram-reverse.svg"

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,67 +1,23 @@
+import { pageComponents } from "@/lib/page"
+import { trpc } from "@/lib/trpc"
+import { PortableText } from "@portabletext/react"
 import Image from "next/image"
 import NoopLayout from "../components/layout/NoopLayout"
 
 const AboutPage = () => {
+  const { data: page } = trpc.page.useQuery({ pageSlug: "about" })
+
   return (
     <div className="flex">
       <div className="w-1/3">
         <h1 className="text-5xl font-semibold mb-12">
-          Other forms of <br />
-          ownership are possible.
+          { page?.title }
         </h1>
         <div className="flex flex-col w-3/4">
-          <p className="mb-3">
-            What <em>is</em> ownership? The answer seems obvious, until you
-            think about it. How is it possible for us to &quot;own&quot; a piece
-            of the earth? Land was there long before us, and will be there long
-            after us.
-          </p>
-          <p className="mb-3">
-            In truth, property is a piece of paper, a contract, giving you
-            rights over a place.
-          </p>
-          <p className="mb-3">
-            Ownership of land is a form of power, and it always has been. And
-            that power shapes almost everything about our lives, our society,
-            our environment, and our economy. Your legal relationship with the
-            place where you live defines your security, your wellbeing and your
-            wealth.
-          </p>
-          <p className="mb-3">
-            Today, property (or &quot;real estate&quot;) is the single largest
-            form of wealth on the planet. Our property system underpins almost
-            every crisis flooding across our timelines every day, from
-            inequality to climate collapse and economic stagnation. And yet we
-            don’t even really have the language to talk about it.
-          </p>
-          <p className="mb-3">This Atlas is an attempt to change that.</p>
-          <p className="mb-3">
-            Other forms of ownership and tenure are possible. In fact, they are
-            already here. Many have been around for thousands of years. Right
-            now, all around the world, communities and countries are designing
-            new, fairer ways to own and steward land and buildings. Historians
-            are rediscovering ancient, traditional and indigenous models of
-            ownership.
-          </p>
-          <p className="mb-3">
-            This atlas has been created as a tool to help map that knowledge.
-            Anyone can contribute, and the knowledge belongs to everyone.
-          </p>
-          <p className="mb-3">
-            Why? Because redesigning how we own land and property is the single
-            most important reform project of our century. There is no path to a
-            successful, flourishing future for humanity that does not include
-            it.
-          </p>
-          <p className="mb-3">
-            The solutions that we need to build that future are already here, we
-            just need to find them.
-          </p>
-          <blockquote className="mb-3 text-gray-400">
-            “The ultimate, hidden truth of the world is that it is something
-            that we make, and could just as easily make differently” – David
-            Graeber
-          </blockquote>
+          <PortableText
+            value={page?.content}
+            components={pageComponents}
+          />
         </div>
       </div>
       <div className="w-2/3 relative flex items-center justify-center">

--- a/pages/licence.tsx
+++ b/pages/licence.tsx
@@ -1,15 +1,21 @@
+import { trpc } from "@/lib/trpc"
 import NoopLayout from "../components/layout/NoopLayout"
+import { PortableText } from '@portabletext/react'
+import { pageComponents } from "../lib/page"
 
 const LicencePage = () => {
+  const { data: page } = trpc.page.useQuery({ pageSlug: "licence"})
+
   return (
     <div className="w-1/3">
       <h1 className="text-5xl font-semibold mb-12">
-        Licence
+        { page?.title }
       </h1>
-      <div className="flex flex-col w-3/4">
-        <p className="mb-3">
-          This is a placeholder sentence.
-        </p>
+      <div className="flex flex-col">
+        <PortableText
+          value={page?.content}
+          components={pageComponents}
+        />
       </div>
     </div>
   )

--- a/pages/licence.tsx
+++ b/pages/licence.tsx
@@ -1,23 +1,12 @@
 import { trpc } from "@/lib/trpc"
 import NoopLayout from "../components/layout/NoopLayout"
-import { PortableText } from '@portabletext/react'
-import { pageComponents } from "../lib/page"
+import { ContentPage } from "@/components/ContentPage"
 
 const LicencePage = () => {
-  const { data: page } = trpc.page.useQuery({ pageSlug: "licence"})
+  const { data: licensePage } = trpc.page.useQuery({ pageSlug: "licence"})
 
   return (
-    <div className="w-1/3">
-      <h1 className="text-5xl font-semibold mb-12">
-        { page?.title }
-      </h1>
-      <div className="flex flex-col">
-        <PortableText
-          value={page?.content}
-          components={pageComponents}
-        />
-      </div>
-    </div>
+    <ContentPage page={licensePage} />
   )
 }
 

--- a/pages/terms-of-use.tsx
+++ b/pages/terms-of-use.tsx
@@ -1,15 +1,21 @@
+import { pageComponents } from "@/lib/page"
+import { trpc } from "@/lib/trpc"
+import { PortableText } from "@portabletext/react"
 import NoopLayout from "../components/layout/NoopLayout"
 
 const TermsOfUsePage = () => {
+  const { data: page } = trpc.page.useQuery({ pageSlug: "terms-of-use" })
+
   return (
     <div className="w-1/3">
       <h1 className="text-5xl font-semibold mb-12">
-        Terms of Use
+        { page?.title }
       </h1>
-      <div className="flex flex-col w-3/4">
-        <p className="mb-3">
-          This is a placeholder sentence.
-        </p>
+      <div className="flex flex-col">
+        <PortableText
+          value={page?.content}
+          components={pageComponents}
+        />
       </div>
     </div>
   )

--- a/pages/terms-of-use.tsx
+++ b/pages/terms-of-use.tsx
@@ -1,23 +1,13 @@
-import { pageComponents } from "@/lib/page"
+import { ContentPage } from "@/components/ContentPage"
 import { trpc } from "@/lib/trpc"
-import { PortableText } from "@portabletext/react"
 import NoopLayout from "../components/layout/NoopLayout"
 
 const TermsOfUsePage = () => {
-  const { data: page } = trpc.page.useQuery({ pageSlug: "terms-of-use" })
+  const { data: termsOfUsePage } = trpc.page.useQuery({ pageSlug: "terms-of-use" })
+  console.log(termsOfUsePage)
 
   return (
-    <div className="w-1/3">
-      <h1 className="text-5xl font-semibold mb-12">
-        { page?.title }
-      </h1>
-      <div className="flex flex-col">
-        <PortableText
-          value={page?.content}
-          components={pageComponents}
-        />
-      </div>
-    </div>
+    <ContentPage page={termsOfUsePage} />
   )
 }
 

--- a/server/routers/_app.ts
+++ b/server/routers/_app.ts
@@ -10,6 +10,7 @@ import {
   patternsWithClassQuery,
   tenureTypeQuery,
   contributorsQuery,
+  pageQuery,
 } from "@/lib/queries"
 import { Entry, Pattern, PatternClass } from "@/lib/types"
 import { z } from "zod"
@@ -62,6 +63,16 @@ export const appRouter = router({
   contributors: procedure.query(
     (): Promise<string[]> => sanityClient.fetch(contributorsQuery)
   ),
+  page: procedure
+    .input(
+      z.object({
+        pageSlug: z.string().optional(),
+      })
+    )
+    .query(
+      ({ input }): Promise<any> =>
+        sanityClient.fetch(pageQuery(input?.pageSlug))
+    ),
 })
 
 // export type definition of API


### PR DESCRIPTION
|Sanity|Atlas|
|---|---|
|![image](https://user-images.githubusercontent.com/20502206/214691640-485bcd6e-8a9b-4d9a-ad18-b10d8ed6032f.png)|![image](https://user-images.githubusercontent.com/20502206/214691151-4487547b-613d-4b5f-ab48-2b7e46d2fc4d.png)|

I'm using Sanity "Block Content" component to allow rich text to be displayed, and currently just styling `p` and `blockquote` tags using `react-portabletext` (https://github.com/portabletext/react-portabletext)

Looks pretty straightforward - as we get a bit more guidance on styling these pages we can add custom styles and components.
