### PR TITLE
feat: Custom icons

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -167,6 +167,7 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
       setOpen(!open);
     }
   }
+  console.log(props.data)
 
   return (
     <div className="m-4">

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -1,10 +1,11 @@
 import { trpc } from "@/lib/trpc"
-import { ChevronUp, Tree } from "@carbon/icons-react"
+import { ChevronUp } from "@carbon/icons-react"
 import clsx from "clsx"
 import _ from "lodash"
 import { useState } from "react"
 import { PatternClass, Term } from "../lib/types"
 import { Carousel } from "./carousel/Carousel"
+import { PatternIcon } from "./layout/ui/PatternIcon"
 
 // TODO: Move to style utils
 // maps patternClass.name to custom color keys defined in tailwind.config.js
@@ -117,7 +118,7 @@ const ExpandableRow = (props: ExpandableRowProps) => {
     >
       <div className="px-4 pb-4">
         <div className="flex justify-between items-start mb-4">
-          <Tree className="mt-4" size={"32"} />
+          <PatternIcon className="mt-4" size="32" pattern={{ iconUrl: term.patternIconUrl }}/>
           <div className="flex justify-between items-center">
             <ChevronUp size={32} className={`${backgroundColorClasses[term.patternClassName]} bg-opacity-20 h-10 w-10 p-2`}/>
             <p className="text-sm text-right pl-4">{term.patternClassName} {term.type.toLowerCase()}</p>
@@ -167,7 +168,6 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
       setOpen(!open);
     }
   }
-  console.log(props.data)
 
   return (
     <div className="m-4">
@@ -184,7 +184,7 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
                 style={{ gridColumn: `span ${term.strength}` }}
                 onClick={() => handleClick(i)}
               >
-                {term.type === "Obligation" && term.strength > 0 && <Tree size={16} color="black" className="ml-2" />}
+                {term.type === "Obligation" && term.strength > 0 && <PatternIcon size="24" className="ml-2 text-black" pattern={{ iconUrl: term.patternIconUrl }}/>}
               </div>
               {showLabels &&
                 <div className="flex-1 h-10 text-black text-sm flex items-center mr-3 text-right" style={{ gridColumn: `span ${8 - term.strength}` }}>
@@ -198,7 +198,7 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
                 style={{ gridColumn: `span ${term.strength}` }}
                 onClick={() => handleClick(i)}
               >
-                {term.type === "Right" && term.strength > 0 && <Tree size={16} color="black" className="mr-2" />}
+                {term.type === "Right" && term.strength > 0 && <PatternIcon size="24" className="mr-2 text-black" pattern={{ iconUrl: term.pattern?.patternIconUrl }} />}
               </div>
             {showLabels &&
                 <div className="flex-1 h-10 text-black text-sm flex items-center justify-start ml-3" style={{ gridColumn: `span ${8 - term.strength}` }}>
@@ -238,6 +238,7 @@ const Chart = (props: Props) => {
       name: term.patternName,
       patternClassName: _.find(patternClasses, ['_id', term.pattern?.class?._ref])?.name,
       patternClassOrder: _.find(patternClasses, ['_id', term.pattern?.class?._ref])?.order,
+      patternIconUrl: term.pattern?.iconUrl,
       type: term.type,
       strength: term.strength,
       description: term.description,

--- a/components/layout/PatternsLayout.tsx
+++ b/components/layout/PatternsLayout.tsx
@@ -1,9 +1,9 @@
 import { trpc } from "@/lib/trpc";
 import { Pattern, PatternClass } from "@/lib/types"
-import { Hotel } from "@carbon/icons-react";
 import clsx from "clsx";
 import { Dispatch, SetStateAction, useState } from "react";
 import { PageNavbar } from "../PageNavbar";
+import { PatternIcon } from "./ui/PatternIcon";
 
 interface PatternsLayoutProps {
   patternClasses?: PatternClass[]
@@ -69,7 +69,7 @@ const PatternItem = (props: { pattern: Pattern, patternClassName: string | undef
   return (
     <div className={`flex mb-4 ${reverse ? "flex-row-reverse" : ""}`}>
       <div className={clsx(`w-1/2 ${patternClassLookup[patternClassName!]} bg-opacity-40 flex items-center justify-center`)}>
-        <Hotel size={32} className="w-1/4 flex-center" />
+        <PatternIcon pattern={pattern} className="w-1/4 flex-center" size={32} />
         <div className="p-4 w-3/4">
           <p className="text-lg">{pattern.name}</p>
           <p className="text-xs">{pattern.description}</p>

--- a/components/layout/PatternsLayout.tsx
+++ b/components/layout/PatternsLayout.tsx
@@ -69,7 +69,7 @@ const PatternItem = (props: { pattern: Pattern, patternClassName: string | undef
   return (
     <div className={`flex mb-4 ${reverse ? "flex-row-reverse" : ""}`}>
       <div className={clsx(`w-1/2 ${patternClassLookup[patternClassName!]} bg-opacity-40 flex items-center justify-center`)}>
-        <PatternIcon pattern={pattern} className="w-1/4 flex-center" size={32} />
+        <PatternIcon pattern={pattern} className="w-1/4 flex justify-center" size={32} />
         <div className="p-4 w-3/4">
           <p className="text-lg">{pattern.name}</p>
           <p className="text-xs">{pattern.description}</p>

--- a/components/layout/ui/PatternIcon.tsx
+++ b/components/layout/ui/PatternIcon.tsx
@@ -3,15 +3,16 @@ import { CarbonIconProps, Hotel } from "@carbon/icons-react";
 import Image from "next/image";
 
 interface PatternIconProps {
-  pattern: Pattern
+  pattern: Partial<Pattern>
   className?: string
   size: CarbonIconProps["size"]
 }
 
-const FallbackIcon = (props: PatternIconProps) => <Hotel size={32} className={props.className}/>
+const FallbackIcon = (props: PatternIconProps) => <Hotel size={props.size} className={props.className}/>
 
 export const PatternIcon = (props: PatternIconProps) => {
   const { pattern, size, className } = props;
+  console.log({pattern})
   return (
     pattern.iconUrl ?
     <div className={className}>

--- a/components/layout/ui/PatternIcon.tsx
+++ b/components/layout/ui/PatternIcon.tsx
@@ -1,0 +1,27 @@
+import { Pattern } from "@/lib/types";
+import { CarbonIconProps, Hotel } from "@carbon/icons-react";
+import Image from "next/image";
+
+interface PatternIconProps {
+  pattern: Pattern
+  className: string
+  size: CarbonIconProps["size"]
+}
+
+const FallbackIcon = (props: PatternIconProps) => <Hotel size={32} className={props.className}/>
+
+export const PatternIcon = (props: PatternIconProps) => {
+  const { pattern, size, className } = props;
+  return (
+    pattern.iconUrl ?
+    <Image
+      priority
+      className={className}
+      src={pattern.iconUrl}
+      height={size}
+      width={size}
+      alt={`${pattern.name} icon`}
+    /> 
+    : <FallbackIcon {...props}/>
+  )
+}

--- a/components/layout/ui/PatternIcon.tsx
+++ b/components/layout/ui/PatternIcon.tsx
@@ -4,7 +4,7 @@ import Image from "next/image";
 
 interface PatternIconProps {
   pattern: Pattern
-  className: string
+  className?: string
   size: CarbonIconProps["size"]
 }
 
@@ -14,14 +14,15 @@ export const PatternIcon = (props: PatternIconProps) => {
   const { pattern, size, className } = props;
   return (
     pattern.iconUrl ?
-    <Image
-      priority
-      className={className}
-      src={pattern.iconUrl}
-      height={size}
-      width={size}
-      alt={`${pattern.name} icon`}
-    /> 
+    <div className={className}>
+      <Image
+        priority
+        src={pattern.iconUrl}
+        height={size}
+        width={size}
+        alt={`${pattern.name} icon`}
+      /> 
+    </div>
     : <FallbackIcon {...props}/>
   )
 }

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -5,7 +5,7 @@ import theme from "tailwindcss/defaultTheme"
 import { A } from "../../lib/fp"
 import { trpc } from "../../lib/trpc"
 import Accordion, { EntryFilterData, AccordionItemData } from "./Accordion"
-import { ChevronLeft, ChevronRight, Hotel } from "@carbon/icons-react"
+import { ChevronLeft, ChevronRight } from "@carbon/icons-react"
 import { toggleSidebar, useStore } from "lib/store"
 import { ChangeEvent, useState } from "react"
 import { EntryType, Pattern, TenureType } from "@/lib/types"
@@ -19,6 +19,7 @@ import {
   useSelection,
 } from "./selection"
 import clsx from "clsx"
+import { PatternIcon } from "../layout/ui/PatternIcon"
 
 const Chevvy = (props: any) => (
   <div className={css.chevvy} {...props}>
@@ -138,7 +139,13 @@ const PatternClassAccordion = () => {
     e.target.checked ? selectPattern(pattern) : deselectPattern(pattern)
   }
 
-  const placeholderPatternClassIcon = <Hotel size={24} />
+  const buildAccordionItemData = (pattern: Pattern): AccordionItemData => ({ 
+    checked: patternNames.includes(pattern.name), 
+    _id: pattern._id, 
+    displayText: pattern.name, 
+    data: pattern, 
+    icon: <PatternIcon size={32} pattern={pattern} className="mr-4"/> 
+  })
 
   return (
     <>
@@ -156,13 +163,7 @@ const PatternClassAccordion = () => {
             items={pipe(
               patterns,
               A.filter((pattern) => pattern.class.name === patternClass.name),
-              A.map((pattern) => ({
-                checked: patternNames.includes(pattern.name),
-                _id: pattern._id,
-                displayText: pattern.name,
-                data: pattern,
-                icon: placeholderPatternClassIcon,
-              }))
+              A.map(buildAccordionItemData)
             )}
           />
         ))

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -5,7 +5,7 @@ import { trpc } from "./trpc"
 import { Entry } from "./types"
 
 export const entriesQuery = `*[_type == "entry"]{...,  entryRating-> { grade }, mainImage {..., file {..., asset-> } }, 'patterns': terms[].pattern->{ name } }`
-export const patternsQuery = `*[_type == "pattern"]`
+export const patternsQuery = groq`*[_type == "pattern"] {..., "iconUrl": icon.asset -> url} `
 export const patternClassesQuery = `*[_type == "patternClass"] | order(order)`
 export const patternsWithClassQuery = groq`
   *[_type == "pattern"]

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -25,6 +25,7 @@ export const patternInfoQuery = (patternClassName: string | null) => `
       *[_type == "pattern"] { 
         ..., 
         class->, 
+        "iconUrl": icon.asset -> url,
         "entryCount": count(* [_type == "entry" && references(^._id)])
       }
       [class.name == "${patternClassName}" && type == "right" && entryCount > 0]
@@ -32,7 +33,8 @@ export const patternInfoQuery = (patternClassName: string | null) => `
     "obligations": 
       *[_type == "pattern"] {
         ..., 
-        class->, 
+        class->,
+        "iconUrl": icon.asset -> url,
         "entryCount": count(* [_type == "entry" && references(^._id)])
       }
       [class.name == "${patternClassName}" && type == "obligation" && entryCount > 0]

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -1,4 +1,5 @@
 import { pipe } from "fp-ts/lib/function"
+import { groq } from "next-sanity"
 import { O, RA } from "./fp"
 import { trpc } from "./trpc"
 import { Entry } from "./types"
@@ -6,7 +7,10 @@ import { Entry } from "./types"
 export const entriesQuery = `*[_type == "entry"]{...,  entryRating-> { grade }, mainImage {..., file {..., asset-> } }, 'patterns': terms[].pattern->{ name } }`
 export const patternsQuery = `*[_type == "pattern"]`
 export const patternClassesQuery = `*[_type == "patternClass"] | order(order)`
-export const patternsWithClassQuery = `*[_type == "pattern"]{..., class -> }[ count(*[_type == "entry" && references(^._id)]) > 0] | order(order)`
+export const patternsWithClassQuery = groq`
+  *[_type == "pattern"]
+  {..., class -> , "iconUrl": icon.asset -> url}
+  [ count(*[_type == "entry" && references(^._id)]) > 0] | order(order)`
 
 export const useGetEntryFromSlug = () => {
   const { data: entries } = trpc.entries.useQuery()

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -25,6 +25,7 @@ export type Pattern = {
   class: PatternClass
   entryCount?: number
   type: "right" | "obligation"
+  iconUrl?: string
 }
 
 export type PatternClass = {

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,15 @@
 const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cdn.sanity.io",
+        pathname: "/images/**",
+      },
+    ],
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
I've uploaded a random Carbon icon to the "Variable rents" pattern on Sanity to test this - https://osl.sanity.studio/desk/pattern;863dedd7-07f2-4950-90af-692880bef23f

**Chart icons**
![image](https://user-images.githubusercontent.com/20502206/214815692-414add8d-b3d9-4643-b36e-dde4201650b1.png)

**Sidebar icons**
![image](https://user-images.githubusercontent.com/20502206/214815767-75f5c59f-9445-4384-8d93-76ff709b419f.png)

**Pattern icons**
![image](https://user-images.githubusercontent.com/20502206/214815896-6cb5af39-3091-4e94-a1dd-7c7b523ca1cb.png)
