### PR TITLE
fix: Chart zero values

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -181,28 +181,28 @@ const ExpandableBarChartByPattern = (props: ExpandableBarChartByPatternProps) =>
           <div className="flex">
             <div className="flex-1 grid" style={{ gridTemplateColumns: `repeat(${gridCols}, minmax(0, 1fr))`, direction: "rtl"}}>
               <div 
-                className={`${term.type === "Obligation" && backgroundColorClasses[term.patternClassName!]} ${term.type === "Obligation" && term.strength > 0 && hoverColorClasses[term.patternClassName!]} h-10 cursor-pointer flex justify-end items-center`} 
-                style={{ gridColumn: `span ${term.strength}` }}
+                className={`${term.type === "Obligation" && term.strength > 0 && backgroundColorClasses[term.patternClassName!]} ${term.type === "Obligation" && hoverColorClasses[term.patternClassName!]} h-10 cursor-pointer flex justify-end items-center`} 
+                style={{ gridColumn: `span ${term.strength || 1}` }}
                 onClick={() => handleClick(i)}
               >
                 {term.type === "Obligation" && <PatternIcon size="24" className="ml-2 text-black" pattern={{ iconUrl: term.patternIconUrl }}/>}
               </div>
               {showLabels &&
-                <div className="flex-1 h-10 text-black text-xs sm:text-sm flex items-center mr-3 text-right" style={{ gridColumn: showLabels ? `span ${8 - term.strength}` : `span ${5 - term.strength}` }}>
+                <div className="flex-1 h-10 text-black text-xs sm:text-sm flex items-center mr-3 text-right" style={{ gridColumn: showLabels ? `span ${term.strength ? 8 - term.strength : 7}` : `span ${term.strength ? 5 - term.strength : 4}` }}>
                   {term.type === "Obligation" && term.name}
                 </div>
               }
             </div>
             <div className="flex-1 grid" style={{ gridTemplateColumns: `repeat(${gridCols}, minmax(0, 1fr))`, direction: "ltr" }}>
               <div 
-                className={`${term.type === "Right" && backgroundColorClasses[term.patternClassName!]} ${term.type === "Right" && term.strength > 0 && hoverColorClasses[term.patternClassName!]} h-10 cursor-pointer flex justify-end items-center`} 
-                style={{ gridColumn: `span ${term.strength}` }}
+                className={`${term.type === "Right" && term.strength > 0 && backgroundColorClasses[term.patternClassName!]} ${term.type === "Right" && hoverColorClasses[term.patternClassName!]} h-10 cursor-pointer flex justify-end items-center`} 
+                style={{ gridColumn: `span ${term.strength || 1}` }}
                 onClick={() => handleClick(i)}
               >
                 {term.type === "Right" && <PatternIcon size="24" className="mr-2 text-black" pattern={{ iconUrl: term.pattern?.patternIconUrl }} />}
               </div>
             {showLabels &&
-                <div className="flex-1 h-10 text-black text-xs sm:text-sm flex items-center justify-start ml-3" style={{ gridColumn: showLabels ? `span ${8 - term.strength}` : `span ${5 - term.strength}` }}>
+                <div className="flex-1 h-10 text-black text-xs sm:text-sm flex items-center justify-start ml-3" style={{ gridColumn: showLabels ? `span ${term.strength ? 8 - term.strength : 7}` : `span ${term.strength ? 5 - term.strength : 4}` }}>
                 {term.type === "Right" && term.name}
               </div> 
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20502206/215128229-bfb3068c-961c-428e-8bdd-db51cce19f04.png)

**Principles**
 - If a term has a zero value, do not give it a colour. This means they're visually easy to spot on charts
 - If a term has a zero value, still give it the spacing of a "1" value. This keeps the layout consistent.

Hopefully once all terms have a strength, we can remove this logic and enforce this at the Sanity level, but hopefully this works for now!