### PR TITLE
fix: Why -> About

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -10,7 +10,7 @@ const Header = () => (
         A map of property rights and obligations across time and space
       </h2>
       <Link href="/about">
-        <a className="pointer-events-auto mt-2 text-sm sm:text-lg opacity-75">Why?</a>
+        <a className="pointer-events-auto mt-2 text-sm sm:text-lg opacity-75 underline hover:opacity-100">About</a>
       </Link>
     </div>
     <div className="h-fit mt-4 flex gap-10 pointer-events-auto text-white">


### PR DESCRIPTION
https://www.notion.so/opensystemslab/Remove-second-circle-thing-from-sidebar-tab-2071d7d64095459e9644729ae0488986

![image](https://user-images.githubusercontent.com/20502206/216060234-14ec72d9-4b4b-4c4f-a94e-369834c2017b.png)
