### PR TITLE
fix: Standard title style across pages

### DIFF
--- a/components/ContentPage.tsx
+++ b/components/ContentPage.tsx
@@ -22,7 +22,7 @@ export const ContentPage = ({ page, title }: ContentPageProps) => {
       <Head>
         <title>{title || page?.title} - The Atlas of Ownership</title>
       </Head>
-      <h1 className="text-3xl sm:text-5xl font-semibold mb-12">
+      <h1 className="title mb-12 sm:min-w-[40vw]">
         {page?.title}
       </h1>
       <div className="flex flex-col">

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -1,15 +1,3 @@
-.title {
-  @apply text-2xl;
-}
-
-@screen sm {
-  .title {
-    font-size: 50px;
-    line-height: 52.5px;
-    letter-spacing: -0.03em;
-  }
-}
-
 .link {
   @apply hidden;
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,7 +5,7 @@ import Search from "./Search"
 const Header = () => (
   <header className="absolute z-10 w-full flex justify-between pointer-events-none text-sm">
     <div className="pl-16 pt-20 sm:pt-10 pr-5 w-3/4 sm:w-1/2 md:w-1/4 text-white">
-      <h1 className={css.title}>The Atlas of Ownership</h1>
+      <h1 className="title">The Atlas of Ownership</h1>
       <h2 className="text-sm sm:text-lg pt-3">
         A map of property rights and obligations across time and space
       </h2>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -70,3 +70,15 @@ a {
     @apply w-auto flex flex-col-reverse;
   }
 }
+
+.title {
+  @apply text-2xl;
+}
+
+@screen sm {
+  .title {
+    font-size: 50px;
+    line-height: 52.5px;
+    letter-spacing: -0.03em;
+  }
+}


### PR DESCRIPTION
Making the header wider than the content doesn't always guarantee one will actually be wider. Based on how important this is we can always increase the different between the header at 40% and text at 33%.

Colours purely indicative!

![image](https://user-images.githubusercontent.com/20502206/216063872-35ed168a-9c7a-4fcd-b0fd-7b6afaaff5b5.png)
