### PR TITLE
fix: Improve "Explore patterns" queries

### DIFF
--- a/components/layout/PatternsLayout.tsx
+++ b/components/layout/PatternsLayout.tsx
@@ -1,8 +1,8 @@
 import { trpc } from "@/lib/trpc";
-import { Page, Pattern, PatternClass } from "@/lib/types"
+import { Page, Pattern, PatternClass, PatternInfo } from "@/lib/types"
 import { PortableText } from "@portabletext/react";
 import clsx from "clsx";
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, useState, useEffect } from "react";
 import { pageComponents } from "../ContentPage";
 import { PageNavbar } from "../PageNavbar";
 import { PatternIcon } from "./ui/PatternIcon";
@@ -74,9 +74,10 @@ const PatternNav = ({ patternClasses, onClick, selectedPatternClass }: PatternNa
   </>
 );
 
-const PatternList = (props: { patternClass: PatternClass | undefined }) => {
-  const { patternClass } = props;
-  const { data: patternInfo, error: patternInfoError } = trpc.patternInfo.useQuery({ patternClassName: patternClass?.name || null })
+const PatternList = (props: { patternClass: PatternClass | undefined, patternInfoList: PatternInfo[] | undefined }) => {
+  const { patternClass, patternInfoList } = props;  
+  const patternInfo = patternInfoList?.find(patternInfo => patternInfo.name === patternClass?.name);
+
   return (
     <section className="p-8 bg-white">
       <p className="mb-4">{patternClass?.description}</p>
@@ -117,15 +118,22 @@ const PatternItem = (props: { pattern: Pattern, patternClassName: string | undef
 
 export const PatternsLayout = (props: PatternsLayoutProps) => {
   const { data: patternsPage } = trpc.page.useQuery({ pageSlug: "patterns" })
+  const { data: patternInfoList, error: patternInfoListError } = trpc.patternInfoList.useQuery();
+
   const { patternClasses } = props;
   const [selectedPatternClass, setSelectedPatternClass] = useState<PatternClass | undefined>(patternClasses?.[0]);
+
+  useEffect(() => {
+    setSelectedPatternClass(patternClasses?.[0])
+  }, [patternClasses])
+  
 
   return (
     <div className="bg-gray-200 text-black z-20 fixed inset-0 overflow-y-auto">
       <PageNavbar variant="light" />
       <Header page={patternsPage}/>
       <PatternNav patternClasses={patternClasses} onClick={setSelectedPatternClass} selectedPatternClass={selectedPatternClass} />
-      <PatternList patternClass={selectedPatternClass} />
+      <PatternList patternClass={selectedPatternClass} patternInfoList={patternInfoList}/>
     </div>
   )
 }

--- a/lib/queries.ts
+++ b/lib/queries.ts
@@ -32,8 +32,9 @@ export const useGetEntryFromSlug = () => {
     )
 }
 
-export const patternInfoQuery = (patternClassName: string | null) => groq`
-  {
+export const patternInfoQuery = groq`
+  *[_type == "patternClass"] {
+    name,
     "rights": 
       *[_type == "pattern"] { 
         ..., 
@@ -41,7 +42,7 @@ export const patternInfoQuery = (patternClassName: string | null) => groq`
         "iconUrl": icon.asset -> url,
         "entryCount": count(* [_type == "entry" && references(^._id)])
       }
-      [class.name == "${patternClassName}" && type == "right" && entryCount > 0]
+      [class.name == ^.name && type == "right" && entryCount > 0]
       | order(entryCount desc),
     "obligations": 
       *[_type == "pattern"] {
@@ -50,9 +51,9 @@ export const patternInfoQuery = (patternClassName: string | null) => groq`
         "iconUrl": icon.asset -> url,
         "entryCount": count(* [_type == "entry" && references(^._id)])
       }
-      [class.name == "${patternClassName}" && type == "obligation" && entryCount > 0]
+      [class.name == ^.name && type == "obligation" && entryCount > 0]
       | order(entryCount desc),
-  }
+  } | order(order)
 `
 
 export const tenureTypeQuery = (

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,6 +39,12 @@ export type PatternClass = {
   }
 }
 
+export type PatternInfo = {
+  name: string,
+  rights: Pattern[]
+  obligations: Pattern[]
+}
+
 export type Reference = {
   name: string
   link: string

--- a/server/routers/_app.ts
+++ b/server/routers/_app.ts
@@ -1,4 +1,4 @@
-import { CarouselItem, Page } from './../../lib/types';
+import { CarouselItem, Page, PatternInfo } from './../../lib/types';
 import { procedure, router } from "../trpc"
 import { sanityClient } from "@/lib/sanity.server"
 import {
@@ -28,15 +28,9 @@ export const appRouter = router({
   patternsWithClass: procedure.query(
     (): Promise<Pattern[]> => sanityClient.fetch(patternsWithClassQuery)
   ),
-  patternInfo: procedure
-    .input(
-      z.object({
-        patternClassName: z.string().nullable(),
-      })
-    )
-    .query(
-      ({ input }): Promise<Record<"rights" | "obligations", Pattern[]>> =>
-        sanityClient.fetch(patternInfoQuery(input?.patternClassName))
+  patternInfoList: procedure.query(
+    (): Promise<PatternInfo[]> =>
+      sanityClient.fetch(patternInfoQuery)
     ),
   tenureType: procedure
     .input(


### PR DESCRIPTION
**Before**
 - A query each and every time you changed tab

**Now**
 - A single (bigger) query upfront, but it seems significantly quicker going from tab to tab

Feels pretty rough and ready, but also a decent improvement on how it was done previously.