### PR TITLE
fix: _id typo, handle "Limitation" types

### DIFF
--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -228,7 +228,7 @@ const Chart = (props: Props) => {
     .map((term: any) => ({
       pattern: _.find(patterns, ['_id', term.pattern?._ref]),
       patternName: _.find(patterns, ['_id', term.pattern?._ref])?.name,
-      type: _.capitalize(_.find(patterns, ['id', term.pattern?._ref])?.type) || term.rightsIntensity > 0 ? "Right" : "Obligation", // because pattern.type is not consistently populated
+      type: _.capitalize(_.find(patterns, ['_id', term.pattern?._ref])?.type) || term.rightsIntensity > 0 ? "Right" : "Obligation", // because pattern.type is not consistently populated
       strength: term.strength, // 1-5
       description: term.description,
       legalMechanisms: term.termLegalMechanisms?.map((mechanism: Record<string, any>) => mechanism.name),

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -228,7 +228,7 @@ const Chart = (props: Props) => {
     .map((term: any) => ({
       pattern: _.find(patterns, ['_id', term.pattern?._ref]),
       patternName: _.find(patterns, ['_id', term.pattern?._ref])?.name,
-      type: _.capitalize(_.find(patterns, ['_id', term.pattern?._ref])?.type) || term.rightsIntensity > 0 ? "Right" : "Obligation", // because pattern.type is not consistently populated
+      type: _.capitalize(_.find(patterns, ['_id', term.pattern?._ref])?.type),
       strength: term.strength, // 1-5
       description: term.description,
       legalMechanisms: term.termLegalMechanisms?.map((mechanism: Record<string, any>) => mechanism.name),
@@ -239,7 +239,7 @@ const Chart = (props: Props) => {
       patternClassName: _.find(patternClasses, ['_id', term.pattern?.class?._ref])?.name,
       patternClassOrder: _.find(patternClasses, ['_id', term.pattern?.class?._ref])?.order,
       patternIconUrl: term.pattern?.iconUrl,
-      type: term.type,
+      type: term.type === "Limitation" ? "Obligation" : term.type,
       strength: term.strength,
       description: term.description,
       legalMechanisms: term.legalMechanisms


### PR DESCRIPTION
So this fixes a bug described here were all pattens show as Obligations - https://www.notion.so/opensystemslab/The-Atlas-of-Ownership-176a5620cdfd4465aacb20562bfe64f7?p=e4216dd381914c1e8236b9910659f0fe&pm=s

This fixes the issue of the term being `undefined` and defaulting to an Obligation, but leaves a few open questions...
 - Are there still many patterns without a `type` populated? (So we need a fallback based on `intensity`)
 - What was our thinking behind having "Rights", "Obligations" and "Limitations" - was it just a semantic thing that we didn't tidy up?

**Fixed example on PR** - https://deploy-preview-113--gorgeous-concha-ffb906.netlify.app/entry/st-nicholas-abbey-tenants-contract

**Same example on `main`** - https://gorgeous-concha-ffb906.netlify.app/entry/st-nicholas-abbey-tenants-contract

**"Limitation" pattern on Sanity** - https://osl.sanity.studio/desk/entry;b1be36bd-72a5-4efe-9606-8978c1ec875e;5cc4a34a-f787-4794-b182-b4205c73d9c1%2Ctype%3Dpattern%2CparentRefPath%3Dterms%5B_key%3D%3D%22bfd3ee8a9183%22%5D.pattern